### PR TITLE
Fix challengeLevel not resetting on new game

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -64,6 +64,7 @@ class WordPourGame {
         this.isPaused = false;
         this.isFrozen = false;
         this.history = [];
+        this.challengeLevel = 1;
 
         // Reset strategic gameplay mechanics
         this.scoringAttemptsRemaining = 5;
@@ -542,7 +543,7 @@ class WordPourGame {
 
         this.isFrozen = true;
 
-        setTimeout(() => {
+        this.freezeTimeout = setTimeout(() => {
             this.isFrozen = false;
         }, 10000); // 10 second freeze
 
@@ -553,6 +554,10 @@ class WordPourGame {
     endGame(victory = false) {
         this.isPlaying = false;
         this.stopTimer();
+        if (this.freezeTimeout) {
+            clearTimeout(this.freezeTimeout);
+            this.freezeTimeout = null;
+        }
 
         // Find longest word
         const longestWord = this.wordsFound.reduce((longest, word) =>


### PR DESCRIPTION
## Summary
- **Fix challenge level reset**: `init()` now resets `this.challengeLevel = 1` so starting a new Challenge game always begins at Level 1 instead of continuing from a previous session's level.
- **Fix freeze timer leak**: The `useFreeze()` setTimeout is now stored as `this.freezeTimeout` and cleared in `endGame()` to prevent the callback from firing after the game has ended.

## Test plan
- [ ] Start a Challenge mode game, advance past Level 1, then quit and start a new Challenge game -- verify it starts at Level 1
- [ ] Use the Freeze power-up, then immediately end/quit the game -- verify no console errors or unexpected state changes from the orphaned timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)