### PR TITLE
Add Firestore security rules and input validation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,50 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // High scores collection — publicly readable, validated writes
+    match /highScores/{document} {
+      // Anyone can read leaderboard entries
+      allow read: if true;
+
+      // Allow creating a score with field validation
+      allow create: if
+        // Must contain exactly the expected fields
+        request.resource.data.keys().hasAll(['name', 'score', 'wordsCreated', 'wordsList', 'mode', 'timestamp']) &&
+        request.resource.data.keys().size() == 6 &&
+
+        // name: non-empty string, max 15 chars
+        request.resource.data.name is string &&
+        request.resource.data.name.size() > 0 &&
+        request.resource.data.name.size() <= 15 &&
+
+        // score: integer in valid range
+        request.resource.data.score is int &&
+        request.resource.data.score >= 0 &&
+        request.resource.data.score <= 10000 &&
+
+        // wordsCreated: non-negative integer
+        request.resource.data.wordsCreated is int &&
+        request.resource.data.wordsCreated >= 0 &&
+
+        // wordsList: must be a list, max 100 entries
+        request.resource.data.wordsList is list &&
+        request.resource.data.wordsList.size() <= 100 &&
+
+        // mode: must be one of the valid game modes
+        request.resource.data.mode in ['zen', 'blitz', 'challenge'] &&
+
+        // timestamp: must be a string (ISO format)
+        request.resource.data.timestamp is string &&
+        request.resource.data.timestamp.size() <= 30;
+
+      // No updates or deletes from clients
+      allow update, delete: if false;
+    }
+
+    // Deny all access to any other collections
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -847,15 +847,27 @@ document.addEventListener('DOMContentLoaded', () => {
     // ==================== FIREBASE INTEGRATION ====================
     async function saveScore(name, score) {
         try {
+            // Client-side validation to match Firestore security rules
+            const sanitizedName = String(name).trim().substring(0, 15);
+            if (!sanitizedName) {
+                showToast('Please enter a valid name!', 'warning');
+                return false;
+            }
+
+            const sanitizedScore = Math.max(0, Math.min(10000, Math.floor(Number(score) || 0)));
+            const wordsCreated = Math.max(0, Math.floor(Number(lastGameResult?.wordCount) || 0));
+            const wordsList = (lastGameResult?.wordsFound || []).slice(0, 100);
+            const mode = ['zen', 'blitz', 'challenge'].includes(currentMode) ? currentMode : 'blitz';
+
             const { collection, addDoc } = window.firestoreModules;
             const db = window.db;
 
             await addDoc(collection(db, "highScores"), {
-                name: name,
-                score: score,
-                wordsCreated: lastGameResult?.wordCount || 0,
-                wordsList: lastGameResult?.wordsFound || [],
-                mode: currentMode,
+                name: sanitizedName,
+                score: sanitizedScore,
+                wordsCreated: wordsCreated,
+                wordsList: wordsList,
+                mode: mode,
                 timestamp: new Date().toISOString()
             });
 


### PR DESCRIPTION
## Summary
- Adds `firestore.rules` with strict field validation for the `highScores` collection: enforces name length (1-15 chars), valid score range (0-10000), valid game modes, required fields, and blocks updates/deletes
- Adds `firebase.json` referencing the rules file for deployment via `firebase deploy`
- Adds matching client-side validation in `saveScore()` to sanitize data before writes
- Denies all access to any collections other than `highScores`

Closes #4

## Test plan
- [ ] Deploy rules with `firebase deploy --only firestore:rules`
- [ ] Verify leaderboard reads still work (public read allowed)
- [ ] Verify score submission works with valid data
- [ ] Verify invalid data (empty name, negative score, invalid mode) is rejected by rules
- [ ] Verify direct SDK writes to other collections are denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)