### PR TITLE
Improve rainbow wildcard performance with trie pruning

### DIFF
--- a/js/dictionary.js
+++ b/js/dictionary.js
@@ -628,4 +628,17 @@ const wordList = [
 
 // Create a Set from the word list, all uppercase for case-insensitive matching
 window.dictionary = new Set(wordList);
-//const dictionary = new Set(wordList.map(word => word.toUpperCase()));
+
+// Build a trie from the dictionary for efficient wildcard lookups
+(function buildTrie() {
+    const root = {};
+    for (const word of wordList) {
+        let node = root;
+        for (const ch of word) {
+            if (!node[ch]) node[ch] = {};
+            node = node[ch];
+        }
+        node['$'] = true; // end-of-word marker
+    }
+    window.dictionaryTrie = root;
+})();

--- a/js/game.js
+++ b/js/game.js
@@ -326,10 +326,46 @@ class WordPourGame {
         return words;
     }
 
-    // Expand rainbow wildcards to all possible letters
+    // Expand rainbow wildcards using trie-based pruning for O(trie) instead of O(26^k)
     expandRainbow(word) {
         if (!word.includes('*')) return [word];
 
+        const trie = window.dictionaryTrie;
+        if (!trie) {
+            // Fallback: brute-force expansion if trie not available
+            return this._expandRainbowBruteForce(word);
+        }
+
+        const results = [];
+        const chars = word.split('');
+
+        const walk = (node, index, built) => {
+            if (index === chars.length) {
+                if (node['$']) results.push(built);
+                return;
+            }
+
+            if (chars[index] === '*') {
+                // Wildcard: try every child in the trie at this position
+                for (const ch in node) {
+                    if (ch === '$') continue;
+                    walk(node[ch], index + 1, built + ch);
+                }
+            } else {
+                // Fixed letter: only follow matching branch
+                const ch = chars[index];
+                if (node[ch]) {
+                    walk(node[ch], index + 1, built + ch);
+                }
+            }
+        };
+
+        walk(trie, 0, '');
+        return results;
+    }
+
+    // Brute-force fallback if trie is unavailable
+    _expandRainbowBruteForce(word) {
         const results = [];
         const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 


### PR DESCRIPTION
## Summary
- Builds a trie from the dictionary word list at startup (one-time cost in `dictionary.js`)
- Replaces the brute-force `expandRainbow()` method (O(26^k) combinations) with a trie-walking approach that prunes invalid branches immediately
- For 2 wildcards, this reduces from 676 dictionary lookups to a single trie traversal; for 3 wildcards, from 17,576 lookups to one traversal
- Keeps a brute-force fallback method (`_expandRainbowBruteForce`) in case the trie is unavailable

Closes #5

## Test plan
- [ ] Verify normal word finding (no wildcards) still works correctly
- [ ] Enable rainbow letters temporarily (`rainbowLetterChance > 0` in config.js) and verify wildcard words are found
- [ ] Confirm no performance lag with multiple rainbow letters in a flask
- [ ] Check that `window.dictionaryTrie` is populated on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)