### PR TITLE
Replace innerHTML with DOM methods in addWordChip

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -636,10 +636,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function addWordChip(wordData) {
         const chip = document.createElement('div');
         chip.className = 'word-chip';
-        chip.innerHTML = `
-            ${wordData.word}
-            <span class="word-score">+${wordData.score}</span>
-        `;
+        chip.appendChild(document.createTextNode(wordData.word + ' '));
+        const scoreSpan = document.createElement('span');
+        scoreSpan.className = 'word-score';
+        scoreSpan.textContent = `+${wordData.score}`;
+        chip.appendChild(scoreSpan);
         elements.wordsList.appendChild(chip);
     }
 


### PR DESCRIPTION
## Summary
- Switch `addWordChip` from an `innerHTML` template-string assignment to `createTextNode` / `createElement` calls.
- Word text comes from the validated dictionary so it can't contain markup today, but this removes the `innerHTML` surface entirely as defense-in-depth and matches the pattern used elsewhere (e.g. leaderboard rendering already uses `textContent` / `escapeHTML`).

## Test plan
- [ ] Play a round and submit words — chips render with word text + `+score` span exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)