### PR TITLE
[Bug] Reset score and combo UI on challenge level advance

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1076,6 +1076,9 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.targetScore.textContent = config.challengeLevels[game.challengeLevel - 1]?.target || 50;
         elements.challengeProgress.style.width = '0%';
         elements.wordsList.innerHTML = '';
+        updateScoreDisplay(game.score);
+        updateComboDisplay(game.combo);
+        elements.comboContainer.classList.remove('active');
         updatePowerupDisplay();
     });
 


### PR DESCRIPTION
## Summary
- After a challenge level is cleared, `game.levelComplete()` resets `score` and `combo` to 0, but the next-level button handler in `app.js` never refreshes those UI elements.
- Players saw the previous level's final score and combo multiplier persist on screen until they scored again on the new level.

This change calls `updateScoreDisplay` / `updateComboDisplay` and clears the active combo class when advancing levels.

## Test plan
- [ ] Play challenge mode; clear level 1.
- [ ] On the level-2 board, verify score reads `0` and combo reads `1x` immediately after closing the level-complete modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)