### PR TITLE
Remove unused positions array in renderLeaderboard

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -918,7 +918,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const positions = ['second', 'first', 'third'];
         const topThree = data.slice(0, 3);
 
         // Reorder for visual display: 2nd, 1st, 3rd


### PR DESCRIPTION
## Summary
- The local `positions = ['second', 'first', 'third']` constant in `renderLeaderboard` (js/app.js) was never read — actual position assignment is computed inline from the loop index a few lines below.

## Test plan
- [ ] Open the leaderboard screen in a browser; verify the podium still renders 1st/2nd/3rd in the correct order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)